### PR TITLE
Switch base to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:14.04
+FROM alpine:latest
 MAINTAINER  Cris G c@cristhekid.com
-ENV DEBIAN_FRONTEND noninteractive
 
 # Install required packages.
 RUN \
-  apt-get update && \
-  apt-get install -yq git python && \
-  rm -rf /var/lib/apt/lists/*
+  apk add --update \
+  git \
+  python \
+  && rm -rf /var/cache/apk/*
 
 # Create Plexpy directory
 RUN mkdir -p /opt/plexpy

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains **Dockerfile** of [PlexPy](https://github.com/drzoidber
 
 ### Base Docker Image
 
-* [library/ubuntu:14.04](https://github.com/docker-library/docs/blob/master/ubuntu/tag-details.md#ubuntu1404)
+* [library/alpine:latest](https://github.com/docker-library/docs/blob/master/alpine/tag-details.md#alpinelatest)
 
 ### Installation
 


### PR DESCRIPTION
# What

- Switch the base image from `ubuntu:14.04` to `alpine:latest`. This decreases the image size from 354.5 MB to 182.3 MB.

- Updated the README for image information. 